### PR TITLE
原版Mirai及Overflow多Onebot实现兼容与部分功能性升级

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,9 +26,9 @@ dependencies {
     implementation("commons-codec:commons-codec:1.15")
     implementation("org.apache.httpcomponents:httpclient:4.5.14")
     implementation("org.jsoup:jsoup:1.15.4")
-    implementation("com.squareup.okhttp3:okhttp:5.0.0-alpha.12")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.madgag:animated-gif-lib:1.4")
-    compileOnly("org.bytedeco:javacv-platform:1.5.10")
+    implementation("org.bytedeco:javacv-platform:1.5.10")
 //    compileOnly
     implementation(kotlin("stdlib-jdk8"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,14 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    val kotlinVersion = "1.6.21"
+    val kotlinVersion = "1.9.20"
     kotlin("jvm") version kotlinVersion
     kotlin("plugin.serialization") version kotlinVersion
 
 
     id("org.jetbrains.kotlin.plugin.noarg") version kotlinVersion
     id("org.jetbrains.kotlin.plugin.allopen") version kotlinVersion
-    id("net.mamoe.mirai-console") version "2.15.0-M1"
+    id("net.mamoe.mirai-console") version "2.16.0"
     id("me.him188.maven-central-publish") version "1.0.0-dev-3"
 }
 
@@ -17,18 +17,18 @@ version = "1.7.6"
 
 repositories {
 //    mavenLocal()
-//    maven("https://maven.aliyun.com/repository/gradle-plugin")
-//    maven("https://maven.aliyun.com/repository/central")
+    maven("https://maven.aliyun.com/repository/central")
+    maven("https://maven.aliyun.com/repository/gradle-plugin")
     mavenCentral()
 }
 dependencies {
-    implementation("org.apache.commons:commons-lang3:3.12.0")
+    implementation("org.apache.commons:commons-lang3:3.14.0")
     implementation("commons-codec:commons-codec:1.15")
-    implementation("org.apache.httpcomponents:httpclient:4.5.13")
-    implementation("org.jsoup:jsoup:1.15.3")
-    implementation("com.squareup.okhttp3:okhttp:5.0.0-alpha.10")
+    implementation("org.apache.httpcomponents:httpclient:4.5.14")
+    implementation("org.jsoup:jsoup:1.15.4")
+    implementation("com.squareup.okhttp3:okhttp:5.0.0-alpha.12")
     implementation("com.madgag:animated-gif-lib:1.4")
-    compileOnly("org.bytedeco:javacv-platform:1.5.7")
+    compileOnly("org.bytedeco:javacv-platform:1.5.10")
 //    compileOnly
     implementation(kotlin("stdlib-jdk8"))
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https://mirrors.cloud.tencent.com/gradle/gradle-7.6.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/hcyacg/Helper.kt
+++ b/src/main/kotlin/com/hcyacg/Helper.kt
@@ -32,7 +32,7 @@ object Helper {
                     .plus(" ·看涩图 +tag ${Command.setu} loli").plus("\n")
                     .plus(" ·看萝莉 ${Command.lolicon} 查询条件 r18,查询条件最多三个用&分割，|为或者,例：少女|姐姐&黑丝|白丝&猫耳|狗耳;如果有r18则必须放在最后，开启18禁模式").plus("\n")
                     .plus(" ·通过tag查找排行榜 ${Command.tag}关键词-页码").plus("\n")
-                    .plus(" ·检测图片的涩情程度并打上标签 检测[图片]")
+                    .plus(" ·检测图片的涩情程度并打上标签 ${Command.detect}[图片]")
             )
         )
 

--- a/src/main/kotlin/com/hcyacg/Nsfw.kt
+++ b/src/main/kotlin/com/hcyacg/Nsfw.kt
@@ -90,8 +90,7 @@ object Nsfw {
 
     suspend fun load(event: GroupMessageEvent) {
         println("检测中")
-        val picUri = DataUtil.getSubString(event.message.toString().replace(" ", ""), "[mirai:image:{", "}.")!!
-            .replace("-", "")
+        val picUri = DataUtil.getImageLink(event.message) ?: return
         val url = "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"
 
         val uri = "https://api.dnlab.net/animepic/upload"

--- a/src/main/kotlin/com/hcyacg/Nsfw.kt
+++ b/src/main/kotlin/com/hcyacg/Nsfw.kt
@@ -90,8 +90,7 @@ object Nsfw {
 
     suspend fun load(event: GroupMessageEvent) {
         println("检测中")
-        val picUri = DataUtil.getImageLink(event.message) ?: return
-        val url = "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"
+        val url = DataUtil.getImageLink(event.message) ?: return
 
         val uri = "https://api.dnlab.net/animepic/upload"
 
@@ -102,7 +101,7 @@ object Nsfw {
                 "image/*".toMediaTypeOrNull(),
                 0, body.size
             )
-        requestBody.addFormDataPart("img", "${picUri}.png", bodies)
+        requestBody.addFormDataPart("img", "image.png", bodies)
 
         headers.add(
             "User-Agent",

--- a/src/main/kotlin/com/hcyacg/Nsfw.kt
+++ b/src/main/kotlin/com/hcyacg/Nsfw.kt
@@ -22,6 +22,7 @@ import java.math.RoundingMode
 import java.net.InetSocketAddress
 import java.net.Proxy
 import java.text.DecimalFormat
+import java.util.*
 import java.util.concurrent.TimeUnit
 
 
@@ -111,7 +112,8 @@ object Nsfw {
             "multipart/form-data".toMediaTypeOrNull(),
             0, body.size
         )
-        requestBody.addFormDataPart("file", "${picUri}.jpeg", bodies)
+        val name = UUID.randomUUID().toString() + ".jpeg"
+        requestBody.addFormDataPart("file", name, bodies)
         requestBody.addFormDataPart("network_type", "general")
 
         var uri = "http://dev.kanotype.net:8003/deepdanbooru/upload"
@@ -145,7 +147,7 @@ object Nsfw {
             uri = "http://${Config.deepdanbooru}/deepdanbooru"
             val requestB = MultipartBody.Builder().setType(MultipartBody.FORM)
 
-            requestB.addFormDataPart("image","${picUri}.jpeg", bodies)
+            requestB.addFormDataPart("image" ,name, bodies)
 
             headers.add("Content-Type", "multipart/form-data;boundary=ebf9f03029db4c2799ae16b5428b06bd1")
             headers.add("Accept", "application/json")

--- a/src/main/kotlin/com/hcyacg/Nsfw.kt
+++ b/src/main/kotlin/com/hcyacg/Nsfw.kt
@@ -103,10 +103,7 @@ object Nsfw {
     suspend fun load(event: GroupMessageEvent) {
         println("监控中……")
         event.subject.sendMessage(At(event.sender).plus("检测中,请稍后"));
-        val url = DataUtil.getImageLink(event.message) ?: return
-
-        val picUri = DataUtil.getSubString(event.message.toString().replace("\\s*".toRegex(), "").replace(" ", ""), "[overflow:image,url=", "]")!!
-
+        val picUri = DataUtil.getImageLink(event.message) ?: return
 
         val requestBody = MultipartBody.Builder().setType(MultipartBody.FORM)
         val body = ImageUtil.getImage(picUri, CacheUtil.Type.NONSUPPORT).toByteArray()

--- a/src/main/kotlin/com/hcyacg/Pixiv.kt
+++ b/src/main/kotlin/com/hcyacg/Pixiv.kt
@@ -27,6 +27,7 @@ import net.mamoe.mirai.event.globalEventChannel
 import net.mamoe.mirai.event.subscribeGroupMessages
 import net.mamoe.mirai.utils.ExternalResource.Companion.toExternalResource
 import java.io.ByteArrayInputStream
+import java.util.concurrent.ConcurrentHashMap
 import java.util.regex.Pattern
 
 object Pixiv : KotlinPlugin(
@@ -55,7 +56,8 @@ object Pixiv : KotlinPlugin(
 //        AutoUpdate.load()
 
 
-
+        val searchImageWaitMap = ConcurrentHashMap<String, Long>()
+        val searchAnimeWaitMap = ConcurrentHashMap<String, Long>()
 
         globalEventChannel().subscribeGroupMessages {
 
@@ -80,11 +82,22 @@ object Pixiv : KotlinPlugin(
                 findUserWorksById.matcher(message.contentToString()).find() && !Setting.black.contains(group.id.toString())
             } quoteReply { UserDetails.findUserWorksById(this) }
             //测试成功
-            val searchInfoByPic: Pattern = Pattern.compile("(?i)^(${Command.searchInfoByPic}).+$")
-            content { searchInfoByPic.matcher(message.contentToString()).find() && !Setting.black.contains(group.id.toString()) } quoteReply {
-                Trace.searchInfoByPic(
-                    this
-                )
+            val searchInfoByPic: Pattern = Pattern.compile("(?i)^(${Command.searchInfoByPic})(?:\\n?.+)?\$")
+            content { searchInfoByPic.matcher(message.contentToString()).find() && !Setting.black.contains(group.id.toString())
+                    &&  (searchAnimeWaitMap["${this.group.id}-${this.sender.id}"]?: 0) < System.currentTimeMillis()
+            } quoteReply {
+                if (DataUtil.getImageLink(this.message) == null) {
+                    searchAnimeWaitMap["${this.group.id}-${this.sender.id}"] = System.currentTimeMillis() + Config.waitTime * 1000
+                    "请在${Config.waitTime}秒内发送搜番图片"
+                } else {
+                    Trace.searchInfoByPic(this)
+                }
+            }
+            content {
+                (searchAnimeWaitMap["${this.group.id}-${this.sender.id}"] ?: 0) >= System.currentTimeMillis()
+            } reply {
+                searchAnimeWaitMap["${this.group.id}-${this.sender.id}"] = 0
+                Trace.searchInfoByPic(this)
             }
 
             content { message.contentToString().contains("检测")  && !Setting.black.contains(group.id.toString()) } reply { Nsfw.load(this) }
@@ -99,10 +112,24 @@ object Pixiv : KotlinPlugin(
             val tag: Pattern = Pattern.compile("(?i)^(${Command.tag})([\\s\\S]*)-([0-9]*[1-9][0-9]*)\$")
             content { tag.matcher(message.contentToString()).find() && !Setting.black.contains(group.id.toString()) } quoteReply { Tag.init(this) }
             //测试成功
-            val picToSearch: Pattern = Pattern.compile("(?i)^(${Command.picToSearch})(\\n){0,1}.+$")
+            val picToSearch: Pattern = Pattern.compile("(?i)^(${Command.picToSearch})(?:\\n?.+)?\$")
             content {
-                picToSearch.matcher(message.contentToString()).find() && !Setting.black.contains(group.id.toString())
-            } quoteReply { SearchPicCenter.forward(this) }
+                picToSearch.matcher(message.contentToString()).find() && !Setting.black.contains(group.id.toString()) &&
+                        (searchImageWaitMap["${this.group.id}-${this.sender.id}"]?: 0) < System.currentTimeMillis()
+            } quoteReply {
+                if (DataUtil.getImageLink(this.message) == null) {
+                    searchImageWaitMap["${this.group.id}-${this.sender.id}"] = System.currentTimeMillis() + Config.waitTime * 1000
+                    "请在${Config.waitTime}秒内发送搜图图片"
+                } else {
+                    SearchPicCenter.forward(this)
+                }
+            }
+            content {
+                (searchImageWaitMap["${this.group.id}-${this.sender.id}"] ?: 0) >= System.currentTimeMillis()
+            } reply {
+                searchImageWaitMap["${this.group.id}-${this.sender.id}"] = 0
+                SearchPicCenter.forward(this)
+            }
 
             val lolicon: Pattern = Pattern.compile("(?i)^(${Command.lolicon})( ([^ ]*)( (r18))?)?\$")
             content { lolicon.matcher(message.contentToString()).find() && !Setting.black.contains(group.id.toString()) } quoteReply { LoliconCenter.load(this) }
@@ -153,8 +180,10 @@ object Pixiv : KotlinPlugin(
 
             val lowPoly = Pattern.compile("(?i)^(${Command.lowPoly}).+\$")
             content { lowPoly.matcher(message.contentToString()).find()  && !Setting.black.contains(group.id.toString())} quoteReply {
-                val picUri = DataUtil.getSubString(this.message.toString().replace(" ", ""), "[mirai:image:{", "}.")!!
-                    .replace("-", "")
+                val picUri = DataUtil.getImageLink(this.message)
+                if (picUri == null) {
+                    "请输入正确的命令 ${Command.lowPoly}图片"
+                }
                 val url = "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"
                 val byte = ImageUtil.getImage(url, CacheUtil.Type.NONSUPPORT).toByteArray()
                 val toExternalResource = LowPoly.generate(

--- a/src/main/kotlin/com/hcyacg/Pixiv.kt
+++ b/src/main/kotlin/com/hcyacg/Pixiv.kt
@@ -100,7 +100,8 @@ object Pixiv : KotlinPlugin(
                 Trace.searchInfoByPic(this)
             }
 
-            content { message.contentToString().contains("检测")  && !Setting.black.contains(group.id.toString()) } reply { Nsfw.load(this) }
+            val detect: Pattern = Pattern.compile("(?i)^(${Command.detect})(\\n){0,1}.+$")
+            content { detect.matcher(message.contentToString()).find() && !Setting.black.contains(group.id.toString()) } reply { Nsfw.load(this) }
 
             val setu: Pattern = Pattern.compile("(?i)^(${Command.setu})\$")
             content { setu.matcher(message.contentToString()).find()  && !Setting.black.contains(group.id.toString()) } reply { SexyCenter.init(this) }

--- a/src/main/kotlin/com/hcyacg/Pixiv.kt
+++ b/src/main/kotlin/com/hcyacg/Pixiv.kt
@@ -184,8 +184,7 @@ object Pixiv : KotlinPlugin(
                 if (picUri == null) {
                     "请输入正确的命令 ${Command.lowPoly}图片"
                 }
-                val url = "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"
-                val byte = ImageUtil.getImage(url, CacheUtil.Type.NONSUPPORT).toByteArray()
+                val byte = ImageUtil.getImage(picUri!!, CacheUtil.Type.NONSUPPORT).toByteArray()
                 val toExternalResource = LowPoly.generate(
                     ByteArrayInputStream(byte),
                     200,

--- a/src/main/kotlin/com/hcyacg/Pixiv.kt
+++ b/src/main/kotlin/com/hcyacg/Pixiv.kt
@@ -82,7 +82,7 @@ object Pixiv : KotlinPlugin(
                 findUserWorksById.matcher(message.contentToString()).find() && !Setting.black.contains(group.id.toString())
             } quoteReply { UserDetails.findUserWorksById(this) }
             //测试成功
-            val searchInfoByPic: Pattern = Pattern.compile("(?i)^(${Command.searchInfoByPic})(\\n){0,1}.+\$")
+            val searchInfoByPic: Pattern = Pattern.compile("(?i)^(${Command.searchInfoByPic})(?:\\n?.+)?\$")
             content { searchInfoByPic.matcher(message.contentToString()).find() && !Setting.black.contains(group.id.toString())
                     &&  (searchAnimeWaitMap["${this.group.id}-${this.sender.id}"]?: 0) < System.currentTimeMillis()
             } quoteReply {

--- a/src/main/kotlin/com/hcyacg/details/PicDetails.kt
+++ b/src/main/kotlin/com/hcyacg/details/PicDetails.kt
@@ -370,7 +370,7 @@ object PicDetails {
                     .headers(headers.build()).get().build()
             ).execute()
 
-            output.writeBytes(response.body.byteStream().readBytes())
+            response.body?.byteStream()?.let { output.writeBytes(it.readBytes()) }
 
             ZipUtil.unzip(dir.path + File.separator + "${ugoiraId}.zip", dir.path + File.separator + "image")
 

--- a/src/main/kotlin/com/hcyacg/initial/Command.kt
+++ b/src/main/kotlin/com/hcyacg/initial/Command.kt
@@ -41,6 +41,10 @@ object Command: AutoSavePluginConfig("Command") {
     @ValueDescription("搜索标签排行榜 tag-萝莉-页码")
     var tag: String by value("tag-")
 
+    @ValueName("detect")
+    @ValueDescription("检测图片的涩情程度并打上标签")
+    var detect: String by value("检测")
+
     @ValueName("help")
     @ValueDescription("帮助")
     var help: String by value("帮助")

--- a/src/main/kotlin/com/hcyacg/initial/Config.kt
+++ b/src/main/kotlin/com/hcyacg/initial/Config.kt
@@ -17,6 +17,10 @@ object Config : AutoSavePluginConfig("Config") {
     @ValueDescription("开关 search:搜索图片的引擎开关 sexy:涩图库来源开关")
     var enable: Enable by value()
 
+    @ValueName("waitTime")
+    @ValueDescription("等待时间 搜图搜番时指令与图片分开发送模式下的等待时间（秒）")
+    var waitTime: Int by value(60)
+
     @ValueName("forward")
     @ValueDescription("转发模式 rankAndTagAndUserByForward:排行榜、标签、作者三个变成转发模式; imageToForward:查看图片详情变成转发模式 可发送该作品的所有图片")
     val forward: ForWard by value()

--- a/src/main/kotlin/com/hcyacg/initial/Config.kt
+++ b/src/main/kotlin/com/hcyacg/initial/Config.kt
@@ -48,6 +48,10 @@ object Config : AutoSavePluginConfig("Config") {
     @ValueDescription("本地图库目录")
     val localImagePath: String by value(System.getProperty("user.dir") + File.separator + "image")
 
+    @ValueName("saucenaoEco")
+    @ValueDescription("Saucenao的省流经济模式 可以节约Token次数 也可避免部分Onebot实现产生浪费 可能降低准确度")
+    var saucenaoEco: Boolean by value(false)
+
     @ValueName("google")
     @ValueDescription("Google搜索配置项 镜像源和搜索显示的数量")
     val googleConfig: GoogleConfig by value()

--- a/src/main/kotlin/com/hcyacg/initial/entity/GoogleConfig.kt
+++ b/src/main/kotlin/com/hcyacg/initial/entity/GoogleConfig.kt
@@ -5,8 +5,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class GoogleConfig(
-    @SerialName("googleUrl")
-    val googleUrl:String = "https://www.google.com.hk",
+    @SerialName("googleImageUrl")
+    val googleImageUrl:String = "https://images.google.com",
     @SerialName("resultNum")
     val resultNum:Int = 2
 )

--- a/src/main/kotlin/com/hcyacg/science/Style2paints.kt
+++ b/src/main/kotlin/com/hcyacg/science/Style2paints.kt
@@ -26,8 +26,7 @@ object Style2paints {
         /**
          * 获取图片的代码
          */
-        val picUri = DataUtil.getImageLink(event.message) ?: return
-        val url = "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"
+        val url = DataUtil.getImageLink(event.message) ?: return
 
         val base64 = Base64.getEncoder().encodeToString(ImageUtil.getImage(url, CacheUtil.Type.NONSUPPORT).toByteArray())
 

--- a/src/main/kotlin/com/hcyacg/science/Style2paints.kt
+++ b/src/main/kotlin/com/hcyacg/science/Style2paints.kt
@@ -26,8 +26,7 @@ object Style2paints {
         /**
          * 获取图片的代码
          */
-        val picUri = DataUtil.getSubString(event.message.toString().replace(" ", ""), "[mirai:image:{", "}.")!!
-            .replace("-", "")
+        val picUri = DataUtil.getImageLink(event.message) ?: return
         val url = "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"
 
         val base64 = Base64.getEncoder().encodeToString(ImageUtil.getImage(url, CacheUtil.Type.NONSUPPORT).toByteArray())

--- a/src/main/kotlin/com/hcyacg/search/Ascii2d.kt
+++ b/src/main/kotlin/com/hcyacg/search/Ascii2d.kt
@@ -64,7 +64,7 @@ object Ascii2d {
             val sslsf = SSLConnectionSocketFactory(sc)
             val httpClient = HttpClients.custom().setSSLSocketFactory(sslsf).build()
 
-            val url = "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"
+            val url = picUri
             val ascii2d = "https://ascii2d.net/search/url/$url"
 //            val headers = mutableMapOf<String,String>()
 //            headers["User-Agent"] = "PostmanRuntime/7.28.4"

--- a/src/main/kotlin/com/hcyacg/search/Ascii2d.kt
+++ b/src/main/kotlin/com/hcyacg/search/Ascii2d.kt
@@ -3,6 +3,7 @@ package com.hcyacg.search
 import com.hcyacg.initial.Config
 import com.hcyacg.initial.Setting
 import com.hcyacg.utils.CacheUtil
+import com.hcyacg.utils.DataUtil
 import com.hcyacg.utils.ImageUtil
 import net.mamoe.mirai.event.events.GroupMessageEvent
 import net.mamoe.mirai.message.data.At
@@ -65,7 +66,7 @@ object Ascii2d {
             val httpClient = HttpClients.custom().setSSLSocketFactory(sslsf).build()
 
 
-            val ascii2d = "https://ascii2d.net/search/url/$picUri"
+            val ascii2d = "https://ascii2d.net/search/url/${DataUtil.urlEncode(picUri)}"
 //            val headers = mutableMapOf<String,String>()
 //            headers["User-Agent"] = "PostmanRuntime/7.28.4"
 

--- a/src/main/kotlin/com/hcyacg/search/Google.kt
+++ b/src/main/kotlin/com/hcyacg/search/Google.kt
@@ -34,7 +34,7 @@ object Google {
         try{
             val host = Config.proxy.host
             val port = Config.proxy.port
-            val uri = "${Config.googleConfig.googleUrl}/searchbyimage?image_url=https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0&hl=zh-CN"
+            val uri = "${Config.googleConfig.googleUrl}/searchbyimage?image_url=${picUri}&hl=zh-CN"
 
             val response: Response = if (host.isBlank() || port == -1) {
                 client.build().newCall(Request.Builder().url(uri).headers(headers.build()).get().build()).execute()

--- a/src/main/kotlin/com/hcyacg/search/Google.kt
+++ b/src/main/kotlin/com/hcyacg/search/Google.kt
@@ -34,7 +34,7 @@ object Google {
         try{
             val host = Config.proxy.host
             val port = Config.proxy.port
-            val uri = "${Config.googleConfig.googleUrl}/searchbyimage?image_url=${picUri}&hl=zh-CN"
+            val uri = "${Config.googleConfig.googleUrl}/searchbyimage?image_url=${DataUtil.urlEncode(picUri)}&hl=zh-CN"
 
             val response: Response = if (host.isBlank() || port == -1) {
                 client.build().newCall(Request.Builder().url(uri).headers(headers.build()).get().build()).execute()

--- a/src/main/kotlin/com/hcyacg/search/Iqdb.kt
+++ b/src/main/kotlin/com/hcyacg/search/Iqdb.kt
@@ -25,7 +25,7 @@ object Iqdb {
         val list = mutableListOf<Message>()
 
         try{
-            val url = "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"
+            val url = picUri
             val lqdb = "https://www.iqdb.org"
             val message: Message = At(event.sender).plus("\n")
 

--- a/src/main/kotlin/com/hcyacg/search/Saucenao.kt
+++ b/src/main/kotlin/com/hcyacg/search/Saucenao.kt
@@ -120,18 +120,7 @@ object Saucenao {
                 double.add(similarity270)
             }
 
-            var temp: Double = 0.0
-            for (i in double.indices) {
-                for (j in i + 1 until double.size) {
-                    if (double[i] > double[j]) {
-                        temp = double[i]
-                        double[i] = double[j]
-                        double[j] = temp
-                    }
-                }
-            }
-
-            when (temp) {
+            when (double.max()) {
                 similarity -> {
                     imageData?.let { mate(event, it)?.let { it1 -> list.add(it1.plus("当前为Saucenao搜索")) } }
                 }
@@ -216,7 +205,7 @@ object Saucenao {
         try {
             data = RequestUtil.request(
                 RequestUtil.Companion.Method.GET,
-                "https://saucenao.com/search.php?db=999&output_type=2&api_key=${Config.token.saucenao}&testmode=1&numres=16&url=${picUri}",
+                "https://saucenao.com/search.php?db=999&output_type=2&api_key=${Config.token.saucenao}&testmode=1&numres=16&url=${DataUtil.urlEncode(picUri)}",
                 requestBody,
                 headers.build()
             )
@@ -263,7 +252,9 @@ object Saucenao {
                 toExternalResource?.close()
             }
 
-            if (!thumbnail!!.contains("https://img3.saucenao.com/")) {
+            if (thumbnail != null &&
+                (!thumbnail.contains("https://img3.saucenao.com/") || !thumbnail.contains("https://img1.saucenao.com/"))
+            ) {
                 At(event.sender).plus("\r\n").plus(Image(imageId!!)).plus("\r\n")
                     .plus("Title: $title").plus("\r\n")
                     .plus("ID: $pixivId").plus("\r\n")
@@ -307,7 +298,7 @@ object Saucenao {
             withContext(Dispatchers.IO) {
                 toExternalResource.close()
             }
-            if (!thumbnail.contains("https://img3.saucenao.com/")) {
+            if (!thumbnail.contains("https://img3.saucenao.com/") || !thumbnail.contains("https://img1.saucenao.com/")) {
                 At(event.sender).plus("\r\n")
                     .plus(Image(imageId)).plus("\r\n")
                     .plus("ID: $danbooruId").plus("\r\n")
@@ -351,7 +342,7 @@ object Saucenao {
             withContext(Dispatchers.IO) {
                 toExternalResource.close()
             }
-            if (!thumbnail.contains("https://img3.saucenao.com/")) {
+            if (!thumbnail.contains("https://img3.saucenao.com/") || !thumbnail.contains("https://img1.saucenao.com/")) {
 
                 At(event.sender).plus("\r\n")
                     .plus(Image(imageId)).plus("\r\n")
@@ -401,7 +392,7 @@ object Saucenao {
             withContext(Dispatchers.IO) {
                 toExternalResource.close()
             }
-            if (!thumbnail.contains("https://img3.saucenao.com/")) {
+            if (!thumbnail.contains("https://img3.saucenao.com/") || !thumbnail.contains("https://img1.saucenao.com/")) {
 
                 At(event.sender).plus("\r\n")
                     .plus(Image(imageId)).plus("\r\n")
@@ -450,7 +441,7 @@ object Saucenao {
             withContext(Dispatchers.IO) {
                 toExternalResource.close()
             }
-            if (!thumbnail.contains("https://img3.saucenao.com/")) {
+            if (!thumbnail.contains("https://img3.saucenao.com/") || !thumbnail.contains("https://img1.saucenao.com/")) {
 
                 At(event.sender).plus("\r\n")
                     .plus(Image(imageId)).plus("\r\n")
@@ -499,7 +490,7 @@ object Saucenao {
             withContext(Dispatchers.IO) {
                 toExternalResource.close()
             }
-            if (!thumbnail.contains("https://img3.saucenao.com/")) {
+            if (!thumbnail.contains("https://img3.saucenao.com/") || !thumbnail.contains("https://img1.saucenao.com/")) {
 
                 At(event.sender).plus("\r\n")
                     .plus(Image(imageId)).plus("\r\n")
@@ -545,7 +536,7 @@ object Saucenao {
             withContext(Dispatchers.IO) {
                 toExternalResource.close()
             }
-            if (!thumbnail.contains("https://img3.saucenao.com/")) {
+            if (!thumbnail.contains("https://img3.saucenao.com/") || !thumbnail.contains("https://img1.saucenao.com/")) {
 
                 At(event.sender).plus("\r\n")
                     .plus(Image(imageId)).plus("\r\n")
@@ -595,7 +586,7 @@ object Saucenao {
             withContext(Dispatchers.IO) {
                 toExternalResource.close()
             }
-            if (!thumbnail.contains("https://img3.saucenao.com/")) {
+            if (!thumbnail.contains("https://img3.saucenao.com/") || !thumbnail.contains("https://img1.saucenao.com/")) {
 
                 At(event.sender).plus("\r\n")
                     .plus(Image(imageId)).plus("\r\n")

--- a/src/main/kotlin/com/hcyacg/search/Saucenao.kt
+++ b/src/main/kotlin/com/hcyacg/search/Saucenao.kt
@@ -39,7 +39,7 @@ object Saucenao {
     /**
      * 通过图片来搜索信息
      */
-    suspend fun picToSearch(event: GroupMessageEvent, picUri: String): List<Message> {
+    suspend fun picToSearch(event: GroupMessageEvent, picUri: String, eco: Boolean): List<Message> {
         val list = mutableListOf<Message>()
 
         try {
@@ -58,80 +58,85 @@ object Saucenao {
 //            val picUri = DataUtil.getSubString(messageChain.toString().replace(" ",""), "[mirai:image:{", "}.")!!
 //                .replace("-", "")
 
-            //旋转三次
-            val rotate90 = rotate(withContext(Dispatchers.IO) {
-                ImageIO.read(URL(picUri))
-            }, 90).toByteArray().toExternalResource()
-            val code90 = getImageLinkFromImage(rotate90.uploadAsImage(event.group))
-            withContext(Dispatchers.IO) {
-                rotate90.close()
-            }
-
-            val rotate180 = rotate(withContext(Dispatchers.IO) {
-                ImageIO.read(URL(picUri))
-            }, 180).toByteArray().toExternalResource()
-            val code180 = getImageLinkFromImage(rotate180.uploadAsImage(event.group))
-            withContext(Dispatchers.IO) {
-                rotate180.close()
-            }
-
-            val rotate270 = rotate(withContext(Dispatchers.IO) {
-                ImageIO.read(URL(picUri))
-            }, 270).toByteArray().toExternalResource()
-            val code270 = getImageLinkFromImage(rotate270.uploadAsImage(event.group))
-            withContext(Dispatchers.IO) {
-                rotate270.close()
-            }
-
-
-            val imageData = getInfo(picUri)
-            val imageData90 = getInfo(code90)
-            val imageData180 = getInfo(code180)
-            val imageData270 = getInfo(code270)
-
-
-            /**
-             * 进行相似度对比，取最大值
-             */
-            var similarity: Double = 0.0
-            var similarity90: Double = 0.0
-            var similarity180: Double = 0.0
-            var similarity270: Double = 0.0
-
-            val double = mutableListOf<Double>()
-
-            if (null != imageData) {
-                similarity = imageData.results?.get(0)?.header?.similarity.toString().toDouble()
-                double.add(similarity)
-            }
-
-            if (null != imageData90) {
-                similarity90 = imageData90.results?.get(0)?.header?.similarity.toString().toDouble()
-                double.add(similarity90)
-            }
-
-            if (null != imageData180) {
-                similarity180 = imageData180.results?.get(0)?.header?.similarity.toString().toDouble()
-                double.add(similarity180)
-            }
-
-            if (null != imageData270) {
-                similarity270 = imageData270.results?.get(0)?.header?.similarity.toString().toDouble()
-                double.add(similarity270)
-            }
-
-            when (double.max()) {
-                similarity -> {
-                    imageData?.let { mate(event, it)?.let { it1 -> list.add(it1.plus("当前为Saucenao搜索")) } }
+            if (eco) {
+                val imageData = getInfo(picUri)
+                imageData?.let { mate(event, it)?.let { it1 -> list.add(it1.plus("当前为Saucenao搜索")) } }
+            } else {
+                //旋转三次
+                val rotate90 = rotate(withContext(Dispatchers.IO) {
+                    ImageIO.read(URL(picUri))
+                }, 90).toByteArray().toExternalResource()
+                val code90 = getImageLinkFromImage(rotate90.uploadAsImage(event.group))
+                withContext(Dispatchers.IO) {
+                    rotate90.close()
                 }
-                similarity90 -> {
-                    imageData90?.let { mate(event, it)?.let { it1 -> list.add(it1.plus("当前为Saucenao搜索")) } }
+
+                val rotate180 = rotate(withContext(Dispatchers.IO) {
+                    ImageIO.read(URL(picUri))
+                }, 180).toByteArray().toExternalResource()
+                val code180 = getImageLinkFromImage(rotate180.uploadAsImage(event.group))
+                withContext(Dispatchers.IO) {
+                    rotate180.close()
                 }
-                similarity180 -> {
-                    imageData180?.let { mate(event, it)?.let { it1 -> list.add(it1.plus("当前为Saucenao搜索")) } }
+
+                val rotate270 = rotate(withContext(Dispatchers.IO) {
+                    ImageIO.read(URL(picUri))
+                }, 270).toByteArray().toExternalResource()
+                val code270 = getImageLinkFromImage(rotate270.uploadAsImage(event.group))
+                withContext(Dispatchers.IO) {
+                    rotate270.close()
                 }
-                similarity270 -> {
-                    imageData270?.let { mate(event, it)?.let { it1 -> list.add(it1.plus("当前为Saucenao搜索")) } }
+
+
+                val imageData = getInfo(picUri)
+                val imageData90 = getInfo(code90)
+                val imageData180 = getInfo(code180)
+                val imageData270 = getInfo(code270)
+
+
+                /**
+                 * 进行相似度对比，取最大值
+                 */
+                var similarity: Double = 0.0
+                var similarity90: Double = 0.0
+                var similarity180: Double = 0.0
+                var similarity270: Double = 0.0
+
+                val double = mutableListOf<Double>()
+
+                if (null != imageData) {
+                    similarity = imageData.results?.get(0)?.header?.similarity.toString().toDouble()
+                    double.add(similarity)
+                }
+
+                if (null != imageData90) {
+                    similarity90 = imageData90.results?.get(0)?.header?.similarity.toString().toDouble()
+                    double.add(similarity90)
+                }
+
+                if (null != imageData180) {
+                    similarity180 = imageData180.results?.get(0)?.header?.similarity.toString().toDouble()
+                    double.add(similarity180)
+                }
+
+                if (null != imageData270) {
+                    similarity270 = imageData270.results?.get(0)?.header?.similarity.toString().toDouble()
+                    double.add(similarity270)
+                }
+
+                when (double.max()) {
+                    similarity -> {
+                        imageData?.let { mate(event, it)?.let { it1 -> list.add(it1.plus("当前为Saucenao搜索")) } }
+                    }
+                    similarity90 -> {
+                        imageData90?.let { mate(event, it)?.let { it1 -> list.add(it1.plus("当前为Saucenao搜索")) } }
+                    }
+                    similarity180 -> {
+                        imageData180?.let { mate(event, it)?.let { it1 -> list.add(it1.plus("当前为Saucenao搜索")) } }
+                    }
+                    similarity270 -> {
+                        imageData270?.let { mate(event, it)?.let { it1 -> list.add(it1.plus("当前为Saucenao搜索")) } }
+                    }
                 }
             }
             return list

--- a/src/main/kotlin/com/hcyacg/search/Saucenao.kt
+++ b/src/main/kotlin/com/hcyacg/search/Saucenao.kt
@@ -9,6 +9,7 @@ import com.hcyacg.utils.RequestUtil
 import com.hcyacg.entity.SaucenaoItem
 import com.hcyacg.initial.Command
 import com.hcyacg.initial.Config
+import com.hcyacg.utils.DataUtil.Companion.getImageLinkFromImage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.*
@@ -58,11 +59,11 @@ object Saucenao {
 //                .replace("-", "")
 
             //旋转三次
-            val url = "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"
+            val url = picUri
             val rotate90 = rotate(withContext(Dispatchers.IO) {
                 ImageIO.read(URL(url))
             }, 90).toByteArray().toExternalResource()
-            val code90 = DataUtil.getSubString(rotate90.uploadAsImage(event.group).imageId.replace("-", ""), "{", "}")
+            val code90 = getImageLinkFromImage(rotate90.uploadAsImage(event.group))
             withContext(Dispatchers.IO) {
                 rotate90.close()
             }
@@ -70,7 +71,7 @@ object Saucenao {
             val rotate180 = rotate(withContext(Dispatchers.IO) {
                 ImageIO.read(URL(url))
             }, 180).toByteArray().toExternalResource()
-            val code180 = DataUtil.getSubString(rotate180.uploadAsImage(event.group).imageId.replace("-", ""), "{", "}")
+            val code180 = getImageLinkFromImage(rotate180.uploadAsImage(event.group))
             withContext(Dispatchers.IO) {
                 rotate180.close()
             }
@@ -78,16 +79,16 @@ object Saucenao {
             val rotate270 = rotate(withContext(Dispatchers.IO) {
                 ImageIO.read(URL(url))
             }, 270).toByteArray().toExternalResource()
-            val code270 = DataUtil.getSubString(rotate270.uploadAsImage(event.group).imageId.replace("-", ""), "{", "}")
+            val code270 = getImageLinkFromImage(rotate270.uploadAsImage(event.group))
             withContext(Dispatchers.IO) {
                 rotate270.close()
             }
 
 
             val imageData = getInfo(picUri)
-            val imageData90 = getInfo(code90!!)
-            val imageData180 = getInfo(code180!!)
-            val imageData270 = getInfo(code270!!)
+            val imageData90 = getInfo(code90)
+            val imageData180 = getInfo(code180)
+            val imageData270 = getInfo(code270)
 
 
             /**
@@ -216,7 +217,7 @@ object Saucenao {
         try {
             data = RequestUtil.request(
                 RequestUtil.Companion.Method.GET,
-                "https://saucenao.com/search.php?db=999&output_type=2&api_key=${Config.token.saucenao}&testmode=1&numres=16&url=https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?",
+                "https://saucenao.com/search.php?db=999&output_type=2&api_key=${Config.token.saucenao}&testmode=1&numres=16&url=${picUri}",
                 requestBody,
                 headers.build()
             )

--- a/src/main/kotlin/com/hcyacg/search/SearchPicCenter.kt
+++ b/src/main/kotlin/com/hcyacg/search/SearchPicCenter.kt
@@ -32,7 +32,7 @@ object SearchPicCenter {
         val srSauceNao = scope.launch {
             if (Config.enable.search.saucenao) {
                 //Saucenao 搜索
-                val picToSearch = Saucenao.picToSearch(event, picUri)
+                val picToSearch = Saucenao.picToSearch(event, picUri, Config.saucenaoEco)
                 picToSearch.forEach {
                     nodes.add(
                         ForwardMessage.Node(

--- a/src/main/kotlin/com/hcyacg/search/SearchPicCenter.kt
+++ b/src/main/kotlin/com/hcyacg/search/SearchPicCenter.kt
@@ -1,5 +1,6 @@
 package com.hcyacg.search
 
+import com.hcyacg.initial.Command
 import com.hcyacg.initial.Config
 import com.hcyacg.utils.DataUtil
 import net.mamoe.mirai.contact.nameCardOrNick
@@ -7,6 +8,7 @@ import net.mamoe.mirai.event.events.GroupMessageEvent
 import net.mamoe.mirai.message.data.At
 import net.mamoe.mirai.message.data.ForwardMessage
 import net.mamoe.mirai.message.data.RawForwardMessage
+import kotlinx.coroutines.*
 
 /**
  * 搜索二次元图片转发中心
@@ -19,79 +21,105 @@ object SearchPicCenter {
         /**
          * 获取图片的代码
          */
-        val picUri = DataUtil.getSubString(event.message.toString().replace(" ", ""), "[mirai:image:{", "}.")!!
-            .replace("-", "")
-
-        if (Config.enable.search.ascii2d) {
-            val picToHtmlSearch = Ascii2d.picToHtmlSearch(event, picUri)
-            //Ascii2d 搜索
-            picToHtmlSearch.forEach {
-                nodes.add(
-                    ForwardMessage.Node(
-                        senderId = event.bot.id,
-                        senderName = event.bot.nameCardOrNick,
-                        time = System.currentTimeMillis().toInt(),
-                        message = it
-                    )
-                )
-            }
+        val picUri = DataUtil.getImageLink(event.message)
+        if (picUri == null) {
+            event.subject.sendMessage("请输入正确的命令 ${Command.picToSearch}图片")
+            return
         }
 
-        if (Config.enable.search.saucenao) {
-            //Saucenao 搜索
-            val picToSearch = Saucenao.picToSearch(event, picUri)
-            picToSearch.forEach {
-                nodes.add(
-                    ForwardMessage.Node(
-                        senderId = event.bot.id,
-                        senderName = event.bot.nameCardOrNick,
-                        time = System.currentTimeMillis().toInt(),
-                        message = it
+        val scope = CoroutineScope(Dispatchers.Default)
+
+        val srSauceNao = scope.launch {
+            if (Config.enable.search.saucenao) {
+                //Saucenao 搜索
+                val picToSearch = Saucenao.picToSearch(event, picUri)
+                picToSearch.forEach {
+                    nodes.add(
+                        ForwardMessage.Node(
+                            senderId = event.bot.id,
+                            senderName = event.bot.nameCardOrNick,
+                            time = System.currentTimeMillis().toInt(),
+                            message = it
+                        )
                     )
-                )
+                }
             }
         }
 
-        if (Config.enable.search.iqdb) {
-            //iqdb搜索
-            val iqdb = Iqdb.picToHtmlSearch(event, picUri)
-            iqdb.forEach {
-                nodes.add(
-                    ForwardMessage.Node(
-                        senderId = event.bot.id,
-                        senderName = event.bot.nameCardOrNick,
-                        time = System.currentTimeMillis().toInt(),
-                        message = it
+        val srAscii2d = scope.launch {
+            if (Config.enable.search.ascii2d) {
+                val picToHtmlSearch = Ascii2d.picToHtmlSearch(event, picUri)
+                //Ascii2d 搜索
+                picToHtmlSearch.forEach {
+                    nodes.add(
+                        ForwardMessage.Node(
+                            senderId = event.bot.id,
+                            senderName = event.bot.nameCardOrNick,
+                            time = System.currentTimeMillis().toInt(),
+                            message = it
+                        )
                     )
-                )
+                }
             }
         }
-        if (Config.enable.search.yandex) {
-            val yandex = Yandex.picToHtmlSearch(event, picUri)
-            yandex.forEach {
-                nodes.add(
-                    ForwardMessage.Node(
-                        senderId = event.bot.id,
-                        senderName = event.bot.nameCardOrNick,
-                        time = System.currentTimeMillis().toInt(),
-                        message = it
+
+        val srIqdb = scope.launch {
+            if (Config.enable.search.iqdb) {
+                //iqdb搜索
+                val iqdb = Iqdb.picToHtmlSearch(event, picUri)
+                iqdb.forEach {
+                    nodes.add(
+                        ForwardMessage.Node(
+                            senderId = event.bot.id,
+                            senderName = event.bot.nameCardOrNick,
+                            time = System.currentTimeMillis().toInt(),
+                            message = it
+                        )
                     )
-                )
+                }
             }
         }
-        if (Config.enable.search.google) {
-            //谷歌搜图
-            val google = Google.load(event, picUri)
-            google.forEach {
-                nodes.add(
-                    ForwardMessage.Node(
-                        senderId = event.bot.id,
-                        senderName = event.bot.nameCardOrNick,
-                        time = System.currentTimeMillis().toInt(),
-                        message = it
+
+        val srYandex = scope.launch {
+            if (Config.enable.search.yandex) {
+                val yandex = Yandex.picToHtmlSearch(event, picUri)
+                yandex.forEach {
+                    nodes.add(
+                        ForwardMessage.Node(
+                            senderId = event.bot.id,
+                            senderName = event.bot.nameCardOrNick,
+                            time = System.currentTimeMillis().toInt(),
+                            message = it
+                        )
                     )
-                )
+                }
             }
+        }
+
+        val srGoogle = scope.launch {
+            if (Config.enable.search.google) {
+                //谷歌搜图
+                val google = Google.load(event, picUri)
+                google.forEach {
+                    nodes.add(
+                        ForwardMessage.Node(
+                            senderId = event.bot.id,
+                            senderName = event.bot.nameCardOrNick,
+                            time = System.currentTimeMillis().toInt(),
+                            message = it
+                        )
+                    )
+                }
+            }
+        }
+
+        // 等待并发完成
+        runBlocking {
+            srSauceNao.join()
+            srAscii2d.join()
+            srIqdb.join()
+            srYandex.join()
+            srGoogle.join()
         }
 
         //合并QQ消息 发送查询到的图片线索
@@ -107,6 +135,4 @@ object SearchPicCenter {
 
         event.subject.sendMessage(forward)
     }
-
-
 }

--- a/src/main/kotlin/com/hcyacg/search/Trace.kt
+++ b/src/main/kotlin/com/hcyacg/search/Trace.kt
@@ -49,11 +49,14 @@ object Trace {
             /**
              * 获取图片的代码
              */
-            val picUri = DataUtil.getSubString(event.message.toString().replace(" ", ""), "[mirai:image:{", "}.")!!
+            /**
+             * 获取图片的代码
+             */
+            val picUri = DataUtil.getImageLink(event.message) ?: return
 
             data = RequestUtil.request(
                 RequestUtil.Companion.Method.GET,
-                "https://api.trace.moe/search?cutBorders&url=https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri.replace("-", "")}/0?",
+                "https://api.trace.moe/search?cutBorders&url=https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?",
                 requestBody,
                 headers.build()
             )

--- a/src/main/kotlin/com/hcyacg/search/Trace.kt
+++ b/src/main/kotlin/com/hcyacg/search/Trace.kt
@@ -56,7 +56,7 @@ object Trace {
 
             data = RequestUtil.request(
                 RequestUtil.Companion.Method.GET,
-                "https://api.trace.moe/search?cutBorders&url=https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?",
+                "https://api.trace.moe/search?cutBorders&url=${picUri}",
                 requestBody,
                 headers.build()
             )

--- a/src/main/kotlin/com/hcyacg/search/Trace.kt
+++ b/src/main/kotlin/com/hcyacg/search/Trace.kt
@@ -54,7 +54,7 @@ object Trace {
             println(picUri)
             data = RequestUtil.request(
                 RequestUtil.Companion.Method.GET,
-                "https://api.trace.moe/search?cutBorders&url=${picUri}",
+                "https://api.trace.moe/search?cutBorders&url=${DataUtil.urlEncode(picUri)}",
                 requestBody,
                 headers.build()
             )

--- a/src/main/kotlin/com/hcyacg/search/Yandex.kt
+++ b/src/main/kotlin/com/hcyacg/search/Yandex.kt
@@ -36,7 +36,7 @@ object Yandex {
         val list = mutableListOf<Message>()
 
         try {
-            val url = "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"
+            val url = picUri
 
             val yandexImageUpload =
                 "https://yandex.com/images-apphost/image-download?url=${url}&cbird=111&images_avatars_size=preview&images_avatars_namespace=images-cbir"

--- a/src/main/kotlin/com/hcyacg/search/Yandex.kt
+++ b/src/main/kotlin/com/hcyacg/search/Yandex.kt
@@ -3,6 +3,7 @@ package com.hcyacg.search
 import com.hcyacg.entity.YandexImage
 import com.hcyacg.entity.YandexSearchResult
 import com.hcyacg.utils.CacheUtil
+import com.hcyacg.utils.DataUtil
 import com.hcyacg.utils.ImageUtil
 import com.hcyacg.utils.RequestUtil
 import kotlinx.serialization.json.Json
@@ -37,7 +38,7 @@ object Yandex {
 
         try {
             val yandexImageUpload =
-                "https://yandex.com/images-apphost/image-download?url=${picUri}&cbird=111&images_avatars_size=preview&images_avatars_namespace=images-cbir"
+                "https://yandex.com/images-apphost/image-download?url=${DataUtil.urlEncode(picUri)}&cbird=111&images_avatars_size=preview&images_avatars_namespace=images-cbir"
             val message: Message = At(event.sender).plus("\n")
 
 

--- a/src/main/kotlin/com/hcyacg/utils/DataUtil.kt
+++ b/src/main/kotlin/com/hcyacg/utils/DataUtil.kt
@@ -16,20 +16,22 @@ class DataUtil {
         fun getImageLink(chain: MessageChain): String? {
             chain.forEach {
                 if (it is Image) {
-                    val pic = it.toString()
-                    if (pic.contains("mirai:image")) {
-                        return pic
-                            .substringAfter("[mirai:image:{")
-                            .substringBefore("}")
-                            .replace("-", "")
-                    } else if (pic.contains("overflow:image")) {
-                        return pic
-                            .substringAfter("[overflow:image,url=http://gchat.qpic.cn/gchatpic_new/0/0-0-")
-                            .substringBefore("/0")
-                    }
+                    return getImageLinkFromImage(it)
                 }
             }
             return null
+        }
+
+        fun getImageLinkFromImage(image: Image): String {
+            val pic = image.toString()
+            return if (pic.contains("overflow:image")) {
+                pic
+                    .substringAfter("[overflow:image,url=")
+                    .substringBefore("?")
+            } else {
+                val picUri = image.imageId.replace("-", "")
+                "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"
+            }
         }
 
         fun getSubString(text: String, left: String?, right: String?): String? {

--- a/src/main/kotlin/com/hcyacg/utils/DataUtil.kt
+++ b/src/main/kotlin/com/hcyacg/utils/DataUtil.kt
@@ -27,7 +27,7 @@ class DataUtil {
             return if (pic.contains("overflow:image")) {
                 pic
                     .substringAfter("[overflow:image,url=")
-                    .substringBefore("?")
+                    .substringBefore("]")
             } else {
                 val picUri = image.imageId.replace("-", "")
                 "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"

--- a/src/main/kotlin/com/hcyacg/utils/DataUtil.kt
+++ b/src/main/kotlin/com/hcyacg/utils/DataUtil.kt
@@ -25,9 +25,7 @@ class DataUtil {
         fun getImageLinkFromImage(image: Image): String {
             val pic = image.toString()
             return if (pic.contains("overflow:image")) {
-                pic
-                    .substringAfter("[overflow:image,url=")
-                    .substringBefore("]")
+                image.imageId
             } else {
                 val picUri = image.imageId.replace("-", "")
                 "https://gchat.qpic.cn/gchatpic_new/0/0-0-${picUri}/0?"

--- a/src/main/kotlin/com/hcyacg/utils/DataUtil.kt
+++ b/src/main/kotlin/com/hcyacg/utils/DataUtil.kt
@@ -32,6 +32,10 @@ class DataUtil {
             }
         }
 
+        fun urlEncode(url: String): String {
+            return URLEncoder.encode(url, "UTF-8")
+        }
+
         fun getSubString(text: String, left: String?, right: String?): String? {
             var result = ""
             var zLen: Int

--- a/src/main/kotlin/com/hcyacg/utils/DataUtil.kt
+++ b/src/main/kotlin/com/hcyacg/utils/DataUtil.kt
@@ -1,5 +1,7 @@
 package com.hcyacg.utils;
 
+import net.mamoe.mirai.message.data.Image
+import net.mamoe.mirai.message.data.MessageChain
 import java.io.UnsupportedEncodingException
 import java.net.URLEncoder
 import java.text.NumberFormat
@@ -11,6 +13,25 @@ import java.text.NumberFormat
  */
 class DataUtil {
     companion object {
+        fun getImageLink(chain: MessageChain): String? {
+            chain.forEach {
+                if (it is Image) {
+                    val pic = it.toString()
+                    if (pic.contains("mirai:image")) {
+                        return pic
+                            .substringAfter("[mirai:image:{")
+                            .substringBefore("}")
+                            .replace("-", "")
+                    } else if (pic.contains("overflow:image")) {
+                        return pic
+                            .substringAfter("[overflow:image,url=http://gchat.qpic.cn/gchatpic_new/0/0-0-")
+                            .substringBefore("/0")
+                    }
+                }
+            }
+            return null
+        }
+
         fun getSubString(text: String, left: String?, right: String?): String? {
             var result = ""
             var zLen: Int

--- a/src/main/kotlin/com/hcyacg/utils/ImageUtil.kt
+++ b/src/main/kotlin/com/hcyacg/utils/ImageUtil.kt
@@ -61,13 +61,15 @@ class ImageUtil {
                     client.proxy(proxy).build().newCall(request).execute()
                 }
 
-                val `in` = response.body.byteStream()
+                val `in` = response.body?.byteStream()
 
 
                 val buffer = ByteArray(2048)
-                var len = 0
-                while (`in`.read(buffer).also { len = it } > 0) {
-                    infoStream.write(buffer, 0, len)
+                var len: Int
+                if (`in` != null) {
+                    while (`in`.read(buffer).also { len = it } > 0) {
+                        infoStream.write(buffer, 0, len)
+                    }
                 }
                 infoStream.write((Math.random() * 100).toInt() + 1)
                 infoStream.close()

--- a/src/main/kotlin/com/hcyacg/utils/RequestUtil.kt
+++ b/src/main/kotlin/com/hcyacg/utils/RequestUtil.kt
@@ -65,7 +65,7 @@ class RequestUtil {
 
 
             if (response!!.isSuccessful) {
-                return response!!.body.string().let {
+                return response!!.body?.string().toString().let {
                     Json.parseToJsonElement(it)
                 }
             }


### PR DESCRIPTION
# 兼容性更改

使用原生API进行图片链接获取而非正则，以期提供更好的兼容性

| 机器人框架 | 底层实现 | 图片链接形式 | Core内UUID代表 |
| --- | --- | --- | --- |
| Mirai | Mirai | `https://gchat.qpic.cn/gchatpic_new/0/0-0-UUID/0` | Mirai UUID |
| Overflow | 泛手机端 | `http://gchat.qpic.cn/gchatpic_new/QQID/GROUPID-ID-UUID/0` | 图片链接|
| Overflow | 泛QQNT | `https://multimedia.nt.qq.com.cn/download?appid=1407&fileid=XXX&rkey=REKY&spec=0` | 图片链接|

所以直接在Overflow中选用链接、原版Mirai中使用UUID拼接的形式更现实，同时因为QQNT的链接中含有URL参数，因此需要将全部以URL参数形式传递图片链接的位置进行编码，预期这个PR能够一口气把三种类型端兼容上（测试过后两个）

# 功能性更改/修复

## 并发式搜图

使用多线程并发的形式进行搜图可以有效降低搜图指令时间

## 图片指令分开发送

搜图、搜番指令实现指令图片分开发送，便于手机使用
![图片指令分开发送](https://github.com/Nekoer/mirai-plugins-pixiv/assets/92856393/4e5c218c-f3dd-4d01-98cf-9b2f8ecd1788)

## 修复谷歌识图实现

修复谷歌实现，并额外搜索相同但不同分辨率的图片，将其定义为`精准搜索`，原有方式改为`相似搜索`
![修复谷歌识图](https://github.com/Nekoer/mirai-plugins-pixiv/assets/92856393/f375d5da-faf0-4ced-8155-de4e9b555b18)

## SauceNao经济模式

增加一个可配置SauceNao的搜索模式，只对SauceNao进行正向的图片搜索，而不进行旋转，有利于降低Token次数的使用，同时Oveflow中已经`uploadAsImage`而未真正发送的图片的UUID存储为Base64编码而非真正的UUID或者图片链接，因此在Overflow中旋转后多次搜索也不现实

## SauceNao图源增加

允许插件发送在`https://img1.saucenao.com/`下的图片

## 增加了检测功能的自定义指令

因为之前检测到有`检测`两个字就运行太吵了（~~而且好像也没成功过~~）

# 其他

可能之前动了一些依赖和镜像源地址

已打包测试过，[ebc6192打包](https://github.com/EvolvedGhost/mirai-plugins-pixiv/releases/tag/v1.7.8-ebc6192)
