### PR TITLE
feat(github action):工件的名称不再是默认的artifact

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -38,10 +38,14 @@ jobs:
       uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
       with:
         arguments: buildPluginLegacy
+      #取文件名
+    - name: Get Plugin Name
+      run: echo "NAME=$(find /home/runner/work/mirai-plugins-pixiv/mirai-plugins-pixiv/build/mirai -name "*.jar" -exec basename {} \;)" >> $GITHUB_ENV
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v3.1.0
       if: success()
       with:
+        name: ${{ env.NAME }}
         path: /home/runner/work/mirai-plugins-pixiv/mirai-plugins-pixiv/build/mirai/*.jar
         retention-days: 0
         if-no-files-found: error


### PR DESCRIPTION
1.获取文件名，发布工件的名称不再是默认的artifact